### PR TITLE
Add inline exclamation mark comments to fortran.tmbundle

### DIFF
--- a/Syntaxes/Fortran - Punchcard.tmLanguage
+++ b/Syntaxes/Fortran - Punchcard.tmLanguage
@@ -576,6 +576,46 @@
 				</dict>
 			</array>
 		</dict>
+		<dict>
+			<key>begin</key>
+			<string>(^[ \t]+)?(?=!)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.whitespace.comment.leading.fortran</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?!\G)</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>!</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.comment.fortran</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\n</string>
+					<key>name</key>
+					<string>comment.line.exclamation.fortran.modern</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>\\\s*\n</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
 	</array>
 	<key>repository</key>
 	<dict>


### PR DESCRIPTION
Many compilers support inline exclamation mark comments with fixed source form[^1][^2]. Here an example for such comments is given[^1]

```Fortran
C Column Numbers:
C        1         2         3         4         5         6         7
C23456789012345678901234567890123456789012345678901234567890123456789012

!IBM* SOURCEFORM (FIXED)
      CHARACTER CHARSTR ; LOGICAL X          ! 2 statements on 1 line
      DO 10 I=1,10
        PRINT *,'this is the index',I  ! with an inline comment
10    CONTINUE
C
       CHARSTR="THIS IS A CONTINUED
     X CHARACTER STRING"
       ! There will be 38 blanks in the string between "CONTINUED"
       ! and "CHARACTER". You cannot have an inline comment on
       ! the initial line because it would be interpreted as part
       ! of CHARSTR (character context).
  100 PRINT *, IERROR
! The following debug lines are compiled as source lines if
! you use -qdlines
D     IF (I.EQ.IDEBUG.AND.
D    +    J.EQ.IDEBUG)     WRITE(6,*) IERROR
D     IF (I.EQ.
D    +  IDEBUG )
D    +  WRITE(6,*) INFO
       END
```

And here is another example[^2]
```Fortran
c      Start expression analyzer 
       CHARACTER S, STACK*80 
       COMMON /PRMS/ N, S, STACK 
       ... 
*      Crack the expression:
       IF ( S .GE. '0' .AND. S .LE. '9' ) THEN ! EoL comment 
              CALL PUSH        ! Save on stack. EoL comment 
d             PRINT *, S       ! Debug comment & EoL comment 
       ELSE 
              CALL TOLOWER ! To lowercase EoL comment 
       END IF 
D      PRINT *, N!       Debug comment & EoL comment 
       ... 
C      Finished 
!       expression analyzer
```
Finally another publicly available example[^3] also uses this feature. All these examples are currently not correctly highlighted. For GitHub, the correct highlight can be checked with Lightshow. Currently the highlight is incorrect[^4], which is fixed by this PR[^5].

[^1]: https://www.ibm.com/docs/en/xcafbg/9.0.0?topic=SS3KZ4_9.0.0/com.ibm.xlf111.bg.doc/xlflr/lines_source_formats.htm
[^2]: https://docs.oracle.com/cd/E19957-01/805-4939/6j4m0vn6l/index.html
[^3]: https://github.com/johannesgerer/jburkardt-f77/blob/master/triangulation/triangulation_prb.f#L3253-L3268
[^4]: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Ftextmate%2Ffortran.tmbundle%2Fblob%2Fmaster%2FSyntaxes%2FFortran%2520-%2520Punchcard.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fjohannesgerer%2Fjburkardt-f77%2Fblob%2Fmaster%2Ftriangulation%2Ftriangulation_prb.f%23L3253-L3268&code=
[^5]: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Ffriedc%2Ffortran.tmbundle%2Fblob%2Fmaster%2FSyntaxes%2FFortran%2520-%2520Punchcard.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fjohannesgerer%2Fjburkardt-f77%2Fblob%2Fmaster%2Ftriangulation%2Ftriangulation_prb.f%23L3253-L3268&code=